### PR TITLE
Increase the allowed minimum overlap length

### DIFF
--- a/flye/main.py
+++ b/flye/main.py
@@ -708,7 +708,7 @@ def main():
                         default=1, help="number of polishing iterations [1]",
                         metavar="int")
     parser.add_argument("-m", "--min-overlap", dest="min_overlap", metavar="int",
-                        type=lambda v: check_int_range(v, 1000, 10000),
+                        type=lambda v: check_int_range(v, 1000, 1000000),
                         default=None, help="minimum overlap between reads [auto]")
     parser.add_argument("--asm-coverage", dest="asm_coverage", metavar="int",
                         default=None, help="reduced coverage for initial "


### PR DESCRIPTION
With very long ONT reads and sufficient coverage, using a larger -m than the allowed default seems to produce better assemblies with fewer contigs in some cases than just prefiltering input reads by length, which also prevents shorter reads from contributing to polishing. 

It looks to me like the 10Kbp upper bound was arbitrary, and I don't haven't seen an indication of unexpected side effects of using values here like 20Kbp. Of course, increasing this parameter leads to lower coverage during graph construction, just as with prefiltering input reads.